### PR TITLE
Update icinga2_prepared_vars.py

### DIFF
--- a/library/icinga2_prepared_vars.py
+++ b/library/icinga2_prepared_vars.py
@@ -34,7 +34,7 @@ class Icinga2PreparedVars(object):
           runner
         """
         content = []
-        pattern = re.compile(r'.*{}:="(?P<var>.*)".*'.format(self.variable), re.MULTILINE)
+        pattern = re.compile(r'.*{}:="(?P<var>[0-9A-Za-z]*)".*'.format(self.variable), re.MULTILINE)
 
         if os.path.isfile(self.default_file):
             with open(self.default_file, "r") as _data:


### PR DESCRIPTION
since icinga2 2.13.0-1 there is a new format in /usr/lib/icinga2/prepare-dirs
: "${ICINGA2_USER:="icinga"}"
: "${ICINGA2_GROUP:="icinga"}"
so we had a wrong icinga user icinga"} in /etc/ansible/facts.d/icinga2.fact