### PR TITLE
Use documented user for master status check

### DIFF
--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -142,8 +142,8 @@
           delegate_to: "{{ icinga2_primary_master }}"
           uri:
             url: "https://{{ icinga2_primary_master }}:{{ icinga2_master_port | default(5665) }}/v1/status/IcingaApplication"
-            url_username: root
-            url_password: "{{ icinga2_api.user['root'].password }}"
+            url_username: icinga2
+            url_password: "{{ icinga2_api.user['icinga2'].password }}"
             validate_certs: false
             method: GET
             return_content: true


### PR DESCRIPTION
To work this check in `get state from primary master` task, user must be already created. We can either document `root` user in README examples or use the documented one `icinga2` . 
It would be better convert  `icinga2_api` variable  from a dict to a list so we can select the fist element, but this needs more changes in role's jija templates etc..