### PR TITLE
install debian missing packages

### DIFF
--- a/tasks/install/prepare.yml
+++ b/tasks/install/prepare.yml
@@ -9,6 +9,12 @@
     - ansible_os_family | lower == 'debian'
     - icinga2_use_external_repo | bool
   block:
+    - name: install needed packages
+      ansible.builtin.package:
+        name:
+          - gpg-agent
+          - python3-jinja2
+          
     - name: add icinga2 GPG key
       ansible.builtin.apt_key:
         id: F51A91A5EE001AA5D77D53C4C6E319C334410682


### PR DESCRIPTION
apt-key module is not working if `gpg-agent` is not installed remotely
same for jinja2. Here are the related errors:
```
  cmd: /usr/bin/apt-key add -
  msg: Unable to add a key from binary data
  rc: 2
  stderr: |-
    Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
    gpg: error running '/usr/bin/gpg-agent': probably not installed
    gpg: failed to start agent '/usr/bin/gpg-agent': Configuration error
    gpg: can't connect to the agent: Configuration error
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
```
&
```
  module_stderr: |-
    Traceback (most recent call last):
      File "<stdin>", line 107, in <module>
      File "<stdin>", line 99, in _ansiballz_main
      File "<stdin>", line 47, in invoke_module
      File "/usr/lib/python3.9/runpy.py", line 210, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/usr/lib/python3.9/runpy.py", line 97, in _run_module_code
        _run_code(code, mod_globals, init_globals,
      File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File "/tmp/ansible_bodsch.core.pip_requirements_payload_5f_nwvsp/ansible_bodsch.core.pip_requirements_payload.zip/ansible_collections/bodsch/core/plugins/modules/pip_requirements.py", line 14, in <module>
      File "<frozen zipimport>", line 259, in load_module
      File "/tmp/ansible_bodsch.core.pip_requirements_payload_5f_nwvsp/ansible_bodsch.core.pip_requirements_payload.zip/ansible_collections/bodsch/core/plugins/module_utils/template/template.py", line 8, in <module>
    ModuleNotFoundError: No module named 'jinja2'
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
 ```